### PR TITLE
ci: update Go version to 1.24 in CI workflow

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.24'
           check-latest: true
 
       - name: Get dependencies


### PR DESCRIPTION
Update the Go version used in the CI workflow from 1.20 to 1.24 to ensure compatibility with the latest Go features and improvements.